### PR TITLE
objective bound fix #43

### DIFF
--- a/src/BnBTree.jl
+++ b/src/BnBTree.jl
@@ -545,7 +545,10 @@ function solvemip(tree::BnBTreeObj)
     # check if already integral
     if are_type_correct(tree.m.solution,tree.m.var_type)
         tree.nsolutions = 1
-        return tree.m
+        objval = getobjectivevalue(tree.m.model)
+        sol = getvalue(tree.m.x)
+        bbound = getobjectivebound(tree.m.model)
+        return IncumbentSolution(objval,sol,:Optimal,bbound)
     end
 
     last_table_arr = []
@@ -605,6 +608,13 @@ function solvemip(tree::BnBTreeObj)
         end
     end
     
+    if length(tree.branch_nodes) > 0
+        bvalue, nidx = findmax([tree.obj_fac*n.best_bound for n in tree.branch_nodes])
+        tree.incumbent.best_bound = bvalue 
+    else
+        tree.incumbent.best_bound = tree.incumbent.objval 
+    end
+
     tree.m.nbranches = counter
 
     time_bnb_solve = time()-time_bnb_solve_start

--- a/src/model.jl
+++ b/src/model.jl
@@ -246,6 +246,8 @@ function MathProgBase.optimize!(m::MINLPBnBModel)
 
         replace_solution!(m, best_known)
         m.nsolutions = bnbtree.nsolutions
+    else
+        m.best_bound = getobjbound(m)
     end
     m.soltime = time()-start
     

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -329,7 +329,24 @@ end
 
     @test status == :Optimal
     @test isapprox(getobjectivevalue(m), 65, atol=opt_atol)
+    @test isapprox(getobjectivebound(m), 65, atol=opt_atol)
     @test isapprox(getvalue(x), [0,0,0,1,1], atol=sol_atol)
+end
+
+@testset "Integer at root" begin
+    println("==================================")
+    println("INTEGER AT ROOT")
+    println("==================================")
+    m = Model(solver=DefaultTestSolver())
+
+    @variable(m, x[1:6] <= 1, Int)
+    @constraint(m, x[1:6] .== 1)
+    @objective(m, Max, sum(x))
+    @NLconstraint(m, x[1]*x[2]*x[3]+x[4]*x[5]*x[6] <= 100)
+    status = solve(m)
+    @test status == :Optimal
+    @test isapprox(getobjectivevalue(m), 6, atol=opt_atol)
+    @test isapprox(getobjectivebound(m), 0, atol=opt_atol) # Ipopt return 0
 end
 
 @testset "Knapsack Max with epsilon" begin


### PR DESCRIPTION
Update objbound after everything finished.
Use best bound of nlp solver if no integral variables or integral in root node.